### PR TITLE
Fix build problem about haxx_payload.bin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 haxx_payload.*
 **/build/*
+utils/lzss

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,17 @@ build/oras_code.bin: oras_code/oras_code.bin
 	@cp oras_code/oras_code.bin build/
 oras_code/oras_code.bin: $(wildcard oras_code/source/*)
 	@cd oras_code && make
-			
-oras_save/main:
+
+build/haxx_payload.bin: utils/lzss
+	@curl -sL -o otherapp.bin http://smea.mtheall.com/get_payload.php?version=NEW-10-6-0-31-JPN
+	@utils/lzss otherapp.bin
+	@rm otherapp.bin
+	@mv otherapp.bin.lzss build/haxx_payload.bin
+
+utils/lzss:
+	@cd utils && make
+
+oras_save/main: build/haxx_payload.bin
 	@cd oras_save && make
 			
 oras_ropdb/ropdb.txt: $(ROPDB_TARGET)
@@ -26,3 +35,4 @@ clean:
 	@rm oras_ropdb/ropdb.txt
 	@cd oras_save && make clean
 	@cd oras_code && make clean
+	@cd utils && make clean

--- a/oras_save/oras_save.s
+++ b/oras_save/oras_save.s
@@ -30,7 +30,7 @@
 	.area 0xE058-0x5000 ; maximum size of the compressed hax payload
 
 			haxx_payload:
-				.incbin "../haxx_payload.bin"
+				.incbin "../build/haxx_payload.bin"
 			haxx_payload_end:
 		
 	.endarea

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -1,0 +1,9 @@
+CC = gcc
+
+all: lzss
+
+lzss: lzss.c
+	@$(CC) -I../oras_code/source -o $@ $?
+
+clean:
+	@rm -f lzss

--- a/utils/lzss.c
+++ b/utils/lzss.c
@@ -1,0 +1,26 @@
+#include <blz.c>
+
+int main(int argc, char**argv) {
+    if (argc < 2) {
+        printf("usage: %s filename", argv[0]);
+        return 1;
+    }
+    FILE* inf = fopen(argv[1], "rb");
+    fseek(inf, 0, 2);
+
+    int buflen = ftell(inf);
+    fseek(inf, 0, 0);
+
+    unsigned char buf[buflen];
+    fread(buf, buflen, buflen, inf);
+    fclose(inf);
+
+    int newlen = 0;
+    unsigned char *newbuf = BLZ_Code(buf, buflen, &newlen, 0);
+
+    char outfn[strlen(argv[1]) + 6];
+    sprintf(outfn, "%s.lzss", argv[1]);
+
+    FILE *outf = fopen(outfn, "wb");
+    fwrite(newbuf, 1, newlen, outf);
+}


### PR DESCRIPTION
This patchset use 10.6J otherapp payload to haxx_payload.bin
- utils/lzss: compress input file using lzss
- oras_save/oras_save.s: change dir `..` to `../build` for payload

Resolve #1
